### PR TITLE
Simplify call function. Vector and boost::oprional types. Int bugs fixed

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,15 @@
+cmake_minimum_required(VERSION 3.1)
+
+project(tarantool-cpp)
+
+# BOOST
+find_package(Boost 1.67.0 COMPONENTS system iostreams)
+include_directories(${Boost_INCLUDE_DIRS})
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED on)
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")
+
+add_executable(test test.cpp)
+
+target_link_libraries(test tarantool ${Boost_LIBRARIES})

--- a/test.cpp
+++ b/test.cpp
@@ -1,10 +1,12 @@
-#include "tarantool-cpp.hpp"
-
 #include <string>
 #include <tuple>
 #include <vector>
 
 #include <iostream>
+
+#include <boost/optional.hpp>
+
+#include "tarantool-cpp.hpp"
 
 void test1() {
     
@@ -26,7 +28,7 @@ void test1() {
     int x;
     unsigned int y;
     
-    smart_istream in(data.data());
+    smart_istream in(data.data(), ptr);
     
     auto f = std::tie(x, y);
     auto t = std::tie(f, a, b);
@@ -50,7 +52,7 @@ void test2() {
     unsigned x;
     std::string f;
     
-    tnt.call("test2", {od, ox}, std::tie(x, d, f));
+    tnt.call2("test2", {od, ox}, std::tie(x, d, f));
     
     assert(od == d);
     assert(ox == x);
@@ -65,7 +67,7 @@ void test3() {
     unsigned ox = 4;
     
     std::string os("STR");
-    std::string name("test2");
+    std::string name("testing");
     
     int a, b, c, d;
     unsigned x;
@@ -74,8 +76,11 @@ void test3() {
     auto t1 = std::tie(a, b, c);
     auto t2 = std::tie(d, x);
     auto t3 = std::tie(s1, s2);
-    
-    tnt.call("test3", {od, ox, os, std::make_tuple(oa, ob, oc)}, std::tie(t1, t2, t3, s3));
+
+    std::tie(t1, t2, t3, s3) = tnt.call<std::tuple<int, int, int>,
+            std::tuple<int, unsigned>,
+            std::tuple<std::string, std::string>,
+            std::string>("test3", {od, ox, os, std::make_tuple(oa, ob, oc)});
     
     assert(oa == a);
     assert(ob == b);
@@ -89,9 +94,54 @@ void test3() {
     assert(name == s3);
 }
 
+void test_optional() {
+    TNT tnt("127.0.0.1", "10001");
+
+    boost::optional<int> value;
+
+    boost::optional<int> result;
+
+    std::tie(result) = tnt.call<boost::optional<int>>("same", {3});
+
+    assert(bool(result));
+    assert(result.get() == 3);
+
+    int add;
+
+    // there is no way to call function with null as argument (((
+    std::tie(result, add) = tnt.call<boost::optional<int>, int>("same", {value, 4});
+
+    assert(add == 4);
+    assert(!bool(result));
+}
+
+void test_vector() {
+    TNT tnt("127.0.0.1", "10001");
+
+    std::vector<std::string> in;
+    std::vector<std::string> out;
+
+    size_t num = 20;
+
+    for (size_t i = 0; i != num; ++i) {
+        in.push_back(std::to_string(i));
+    }
+
+    int add;
+    std::tie(out, add) = tnt.call<std::vector<std::string>, int>("same", {in, 5});
+
+    assert(add == 5);
+    assert(out.size() == num);
+
+    for (size_t i = 0; i != num; ++i) {
+        assert(out[i] == std::to_string(i));
+    }
+}
 
 int main() {
     test1();
     test2();
     test3();
+    test_optional();
+    test_vector();
 }

--- a/test.lua
+++ b/test.lua
@@ -4,6 +4,10 @@ box.cfg{
 
 box.schema.user.grant('guest', 'read,write,execute', 'universe')
 
+function same(...)
+    return ...
+end
+
 function test2(a, b)
     return b, a, "test"
 end
@@ -11,5 +15,5 @@ end
 function test3(int, uint, string, array_of_int)
     local a2 = {int, uint}
     local a3 = {string, string}
-    return array_of_int, a2, a3, "test3"
+    return array_of_int, a2, a3, "testing"
 end


### PR DESCRIPTION
Fixed int bug with positive integers.
Added vector and boost::optional supports
Method `call` renamed as `call2`
New call function add
